### PR TITLE
provde a self.view_range definition

### DIFF
--- a/api/behaviors.lua
+++ b/api/behaviors.lua
@@ -1456,6 +1456,7 @@ creatura.register_utility("animalia:walk_ahead_of_player", function(self, player
 		tpos.z = tpos.z + dir.z
 		self.status = self:memorize("status", "following")
 		local dist = vec_dist(pos, tpos)
+		self.view_range = math.abs(tpos.x) + 80
 		if dist > self.view_range then
 			self.status = self:memorize("status", "")
 			return true


### PR DESCRIPTION
When it was nil, the mod would crash the game upon spawning cats and trying to play with them. This is more of a makeshift solution, because vector_add method doesn't work.