### PR TITLE
Fix the behaviors.lua random function

### DIFF
--- a/api/behaviors.lua
+++ b/api/behaviors.lua
@@ -12,7 +12,18 @@ local floor = math.floor
 local pi = math.pi
 local sin = math.sin
 local rad = math.rad
-local random = math.random
+
+-- fix for negative coordinates
+local function random(a,b)
+	if b == nil then
+		return math.random(a)
+	elseif a < b then
+		return math.random(a,b)
+	else
+		return math.random(b,a)
+	end
+end
+
 
 local function diff(a, b) -- Get difference between 2 angles
 	return atan2(sin(b - a), cos(b - a))


### PR DESCRIPTION
Sometimes the arguments to the random function in behaviors.lua are swapped because of negative coordinates, this commit introduces a wrapper for the random function which makes sure that math.random gets its arguments in the correct order.