### PR TITLE
Fix crashes on PUC Lua 5.1

### DIFF
--- a/api/behaviors.lua
+++ b/api/behaviors.lua
@@ -527,9 +527,9 @@ function animalia.action_wander_walk(self, timer, pos2, speed, anim)
 	local check_timer = 0.25
 	timer = timer or 2
 	pos2 = pos2 or {
-		x = pos.x + random(width, -width),
+		x = pos.x + random(-width, width),
 		y = pos.y,
-		z = pos.z + random(width, -width)
+		z = pos.z + random(-width, width)
 	}
 	local function func(_self)
 		pos = _self.object:get_pos()
@@ -573,9 +573,9 @@ function animalia.action_wander_fly(self, timer, pos2)
 	local check_timer = 0.25
 	timer = timer or 2
 	pos2 = pos2 or {
-		x = pos.x + random(width, -width),
-		y = pos.y + random(width, -width),
-		z = pos.z + random(width, -width)
+		x = pos.x + random(-width, width),
+		y = pos.y + random(-width, width),
+		z = pos.z + random(-width, width)
 	}
 	local function func(_self)
 		pos = _self.object:get_pos()

--- a/mobs/horse.lua
+++ b/mobs/horse.lua
@@ -3,6 +3,10 @@
 -----------
 
 local random = math.random
+-- Like `random`, but swaps `from` and `to` if needed.
+local function randint(from, to)
+	return random(math.min(from, to), math.max(from, to))
+end
 
 local follows = {}
 
@@ -266,9 +270,9 @@ creatura.register_mob("animalia:horse", {
 			tex_no = mate_ent.texture_no
 		end
 		ent:memorize("texture_no", tex_no)
-		ent:memorize("speed", random(mate_ent.speed, self.speed))
-		ent:memorize("jump_power", random(mate_ent.jump_power, self.jump_power))
-		ent:memorize("max_health", random(mate_ent.max_health, self.max_health))
+		ent:memorize("speed", randint(mate_ent.speed, self.speed))
+		ent:memorize("jump_power", randint(mate_ent.jump_power, self.jump_power))
+		ent:memorize("max_health", randint(mate_ent.max_health, self.max_health))
 		ent.speed = ent:recall("speed")
 		ent.jump_power = ent:recall("jump_power")
 		ent.max_health = ent:recall("max_health")


### PR DESCRIPTION
Closes #60. I `grep`ped for all usages of `random`; I think I caught all the ones that may use a range which is the wrong way around.

Side note: [strictest](https://github.com/appgurueu/strictest) would've caught this on LuaJIT (it also catches two shady instances of you indexing strings as if they were tables etc.).