### PR TITLE
fix override item

### DIFF
--- a/api/behaviors.lua
+++ b/api/behaviors.lua
@@ -56,8 +56,8 @@ if farming_enabled then
 			if farming.registered_plants[item_string]
 			or farming.registered_plants[item_name] then
 				def.groups.crop = growth_stage
+				minetest.override_item(name, {groups = def.groups})
 			end
-			minetest.register_node(":" .. name, def)
 		end
 	end)
 end


### PR DESCRIPTION
This fixes the mod_origin of reregistered items being "??"
It's problematic when using the unified inventory mod.
Look a the forum topic for more detail.
https://forum.minetest.net/viewtopic.php?f=6&t=29806