### PR TITLE
[no sq] Add ethereal compactibility

### DIFF
--- a/api/api.lua
+++ b/api/api.lua
@@ -780,7 +780,7 @@ local function assign_biome_group(name)
 	local y_max = def.y_max
 	for group, params in pairs(animalia.registered_biome_groups) do -- k, v in pairs
 		if name:find(params.name_kw or "")
-		and turf and turf:find(params.turf_kw or "")
+		and turf and ((turf:find(params.turf_kw or "")) or (params.turf_in and params.turf_in[turf] or false))
 		and heat >= params.min_heat
 		and heat <= params.max_heat
 		and humidity >= params.min_humidity

--- a/init.lua
+++ b/init.lua
@@ -65,6 +65,14 @@ animalia.food_wheat = {}
 animalia.food_seeds = {}
 animalia.food_crops = {}
 animalia.food_bear = {}
+animalia.consumable_grass = {
+	["default:dirt_with_grass"] = "default:dirt",
+	["ethereal:bamboo_dirt"] = "default:dirt",
+	["ethereal:grove_dirt"] = "default:dirt",
+	["ethereal:cold_dirt"] = "default:dirt",
+	["ethereal:prairie_dirt"] = "default:dirt",
+	["default:dry_dirt_with_dry_grass"] = "default:dry_dirt",
+}
 
 minetest.register_on_mods_loaded(function()
 	if minetest.get_modpath("farming")

--- a/mobs/cat.lua
+++ b/mobs/cat.lua
@@ -2,15 +2,15 @@
 -- Cat --
 ---------
 
-local follow = {
-	"animalia:poultry_raw"
-}
+local follow = {}
 
-if minetest.registered_items["ethereal:fish_raw"] then
-	follow = {
-		"ethereal:fish_raw",
-		"animalia:poultry_raw"
-	}
+for _, item in ipairs({
+	"ethereal:fish_raw",
+	"ethereal:fish_cod",
+	"ethereal:fish_cichlid",
+	"animalia:poultry_raw",
+}) do
+	table.insert(follow, item)
 end
 
 creatura.register_mob("animalia:cat", {

--- a/mobs/horse.lua
+++ b/mobs/horse.lua
@@ -227,10 +227,7 @@ creatura.register_mob("animalia:horse", {
 	-- Animalia Props
 	catch_with_net = true,
 	catch_with_lasso = true,
-	consumable_nodes = {
-		["default:dirt_with_grass"] = "default:dirt",
-		["default:dry_dirt_with_dry_grass"] = "default:dry_dirt"
-	},
+	consumable_nodes = animalia.consumable_grass,
 	head_data = {
 		bone = "Neck.CTRL",
 		offset = {x = 0, y = 1.4, z = 0.0},

--- a/mobs/reindeer.lua
+++ b/mobs/reindeer.lua
@@ -59,16 +59,7 @@ creatura.register_mob("animalia:reindeer", {
 	flee_puncher = true,
 	catch_with_net = true,
 	catch_with_lasso = true,
-	consumable_nodes = {
-		{
-			name = "default:dirt_with_grass",
-			replacement = "default:dirt"
-		},
-		{
-			name = "default:dry_dirt_with_dry_grass",
-			replacement = "default:dry_dirt"
-		}
-	},
+	consumable_nodes = animalia.consumable_grass,
 	head_data = {
 		offset = {x = 0, y = 0.55, z = 0},
 		pitch_correction = -45,

--- a/mobs/sheep.lua
+++ b/mobs/sheep.lua
@@ -84,10 +84,7 @@ creatura.register_mob("animalia:sheep", {
 	flee_puncher = true,
 	catch_with_net = true,
 	catch_with_lasso = true,
-	consumable_nodes = {
-		["default:dirt_with_grass"] = "default:dirt",
-		["default:dry_dirt_with_dry_grass"] = "default:dry_dirt"
-	},
+	consumable_nodes = animalia.consumable_grass,
 	head_data = {
 		offset = {x = 0, y = 0.41, z = 0},
 		pitch_correction = -45,

--- a/mod.conf
+++ b/mod.conf
@@ -1,6 +1,6 @@
 name = animalia
 depends = creatura
-optional_depends = default, mcl_player, farming, hunger_ng, hbhunger, 3d_armor
+optional_depends = default, mcl_player, farming, hunger_ng, hbhunger, 3d_armor, ethereal
 description = Adds unique and consistantly designed Animals
 title = Animalia
 author = ElCeejo


### PR DESCRIPTION
This PR adds some type of dirt from ethereal into the list of consumable nodes and search criteria of "grass" biomes. This maintains ethereal compatibility. 

Note that the two top node search criteria, `turf_kw`, and `turf_in`, are included using an OR clause. That is any biomes matching either one would be included in that biome group.

In the second commit, I added more fishes for cats.