### PR TITLE
Add hunger_ng and hbhunger support

### DIFF
--- a/craftitems.lua
+++ b/craftitems.lua
@@ -314,6 +314,44 @@ register_egg("animalia:song_bird_egg", {
 	mob = "animalia:bird"
 })
 
+-- Hunger support --
+
+if minetest.get_modpath("hunger_ng") then
+	hunger_ng.add_hunger_data("animalia:beef_raw", {satiates = 1, heals = -1})
+	hunger_ng.add_hunger_data("animalia:beef_cooked", {satiates = 8})
+	hunger_ng.add_hunger_data("animalia:mutton_raw", {satiates = 1, heals = -1})
+	hunger_ng.add_hunger_data("animalia:mutton_cooked", {satiates = 6})
+	hunger_ng.add_hunger_data("animalia:rat_raw", {satiates = 1, heals = -2})
+	hunger_ng.add_hunger_data("animalia:rat_cooked", {satiates = 4})
+	hunger_ng.add_hunger_data("animalia:porkchop_raw", {satiates = 1, heals = -1})
+	hunger_ng.add_hunger_data("animalia:porkchop_cooked", {satiates = 8})
+	hunger_ng.add_hunger_data("animalia:poultry_raw", {satiates = 1, heals = -1})
+	hunger_ng.add_hunger_data("animalia:poultry_cooked", {satiates = 3})
+	hunger_ng.add_hunger_data("animalia:venison_raw", {satiates = 1, heals = -2})
+	hunger_ng.add_hunger_data("animalia:venison_cooked", {satiates = 8})
+	hunger_ng.add_hunger_data("animalia:chicken_egg_fried", {satiates = 4})
+	hunger_ng.add_hunger_data("animalia:song_bird_egg_fried", {satiates = 4})
+	hunger_ng.add_hunger_data("animalia:turkey_egg_fried", {satiates = 4})
+end
+
+if minetest.get_modpath("hbhunger") then
+	hbhunger.register_food("animalia:beef_raw", 1, "", 0, -1)
+	hbhunger.register_food("animalia:beef_cooked", 12)
+	hbhunger.register_food("animalia:mutton_raw", 1, "", 0, -1)
+	hbhunger.register_food("animalia:mutton_cooked", 9)
+	hbhunger.register_food("animalia:rat_raw", 1, "", 0, -1)
+	hbhunger.register_food("animalia:rat_cooked", 6)
+	hbhunger.register_food("animalia:porkchop_raw", 1, "", 0, -1)
+	hbhunger.register_food("animalia:porkchop_cooked", 12)
+	hbhunger.register_food("animalia:poultry_raw", 1, "", 0, -1)
+	hbhunger.register_food("animalia:poultry_cooked", 9)
+	hbhunger.register_food("animalia:venison_raw", 1, "", 0, -1)
+	hbhunger.register_food("animalia:venison_cooked", 12)
+	hbhunger.register_food("animalia:chicken_egg_fried", 6)
+	hbhunger.register_food("animalia:song_bird_egg_fried", 6)
+	hbhunger.register_food("animalia:turkey_egg_fried", 6)
+end
+
 ----------
 -- Misc --
 ----------

--- a/mod.conf
+++ b/mod.conf
@@ -1,6 +1,6 @@
 name = animalia
 depends = creatura
-optional_depends = default, mcl_player, farming
+optional_depends = default, mcl_player, farming, hunger_ng, hbhunger
 description = Adds unique and consistantly designed Animals
 title = Animalia
 author = ElCeejo


### PR DESCRIPTION
Adds support for the [hunger_ng](https://content.minetest.net/packages/Linuxdirk/hunger_ng/) and [hbhunger](https://content.minetest.net/packages/Wuzzy/hbhunger/) mods.

The values I used were added by me and I accept that they aren't final. Feel free to tweak them to your preference.