### PR TITLE
Add '3d_armor' as optional dependency

### DIFF
--- a/mod.conf
+++ b/mod.conf
@@ -1,6 +1,6 @@
 name = animalia
 depends = creatura
-optional_depends = default, mcl_player, farming
+optional_depends = default, mcl_player, farming, 3d_armor
 description = Adds unique and consistantly designed Animals
 title = Animalia
 author = ElCeejo


### PR DESCRIPTION
The game crashed when I tried to start it in a specific mod constellation.
Found that the cause was that '3d_armor' wasn't listed as an optional dependency here, so I added it.
Now it works fine.