### PR TITLE
Fix Failed to generate "[sheet:4x4:3,4"

### DIFF
--- a/api/api.lua
+++ b/api/api.lua
@@ -351,7 +351,7 @@ function animalia.add_food_particle(self, item_name)
 		image = def.tiles[1].name or def.tiles[1]
 	end
 	if image then
-		local crop = "^[sheet:4x4:" .. random(4) .. "," .. random(4)
+		local crop = "^[sheet:4x4:" .. random(0, 3) .. "," .. random(0, 3)
 		minetest.add_particlespawner({
 			pos = head_pos,
 			time = 0.5,


### PR DESCRIPTION
This PR fixes this client-side texture error:

```text
ERROR[Main]: generateImage(): Failed to generate "[sheet:4x4:3,4"
```

The tile positions are 0-indexed, not 1-indexed.