### PR TITLE
Make spawner more like air

### DIFF
--- a/api/spawning.lua
+++ b/api/spawning.lua
@@ -304,7 +304,11 @@ minetest.register_node("animalia:spawner", {
 	walkable = false,
 	pointable = false,
 	sunlight_propagates = true,
-	groups = {oddly_breakable_by_hand = 1, not_in_creative_inventory = 1}
+	drop = "",
+	diggable = false,
+	floodable = true,
+	buildable_to = true,
+	groups = {not_in_creative_inventory = 1}
 })
 
 minetest.register_decoration({


### PR DESCRIPTION
This PR makes the ABM spawner behave more like air. After this change:

- Spawners can never be dug, if somehow dug, will not drop anything
- Spawners can be flooded and displaced by other blocks

This PR is ready for review.