### PR TITLE
fix crash in animalia.action_melee when target disappears immediately when punched

### DIFF
--- a/api/mob_ai.lua
+++ b/api/mob_ai.lua
@@ -591,12 +591,14 @@ function animalia.action_melee(self, target)
 		if stage == 2
 		and dist < mob.width + 1 then
 			mob:punch_target(target)
-			local knockback = minetest.calculate_knockback(
-				target, mob.object, 1.0,
-				{damage_groups = {fleshy = mob.damage}},
-				dir, 2.0, mob.damage
-			)
-			target:add_velocity({x = dir.x * knockback, y = dir.y * knockback, z = dir.z * knockback})
+			if target:get_pos() then -- target may have died and disappeared
+				local knockback = minetest.calculate_knockback(
+					target, mob.object, 1.0,
+					{damage_groups = {fleshy = mob.damage}},
+					dir, 2.0, mob.damage
+				)
+				target:add_velocity({x = dir.x * knockback, y = dir.y * knockback, z = dir.z * knockback})
+			end
 
 			stage = 3
 		end


### PR DESCRIPTION
some other mobs mods do not have a death animation and instead mobs disappear immediately when they're punched. This PR fixes the issue that occurs when using `animalia` and `nssm` together with the `mobs_attack_creatura` setting enabled when getting `animalia` wolves to fight `nssm` ducks.