### PR TITLE
Add paramtype="light" to animalia:spawner to prevent shadows from spawner

### DIFF
--- a/api/spawning.lua
+++ b/api/spawning.lua
@@ -303,6 +303,7 @@ minetest.register_node("animalia:spawner", {
 	drawtype = "airlike",
 	walkable = false,
 	pointable = false,
+	paramtype = "light",
 	sunlight_propagates = true,
 	groups = {oddly_breakable_by_hand = 1, not_in_creative_inventory = 1}
 })


### PR DESCRIPTION
Without `paramtype = "light"` on `animalia:spawner`, the spawner nodes can cast subtle shadows. Adding this paramtype prevents it from casting shadows.