### PR TITLE
change random(4) to random(0, 3) on crop sheet:4x4 for texture

### DIFF
--- a/api/api.lua
+++ b/api/api.lua
@@ -348,7 +348,7 @@ function animalia.add_food_particle(self, item_name)
 		image = def.tiles[1].name or def.tiles[1]
 	end
 	if image then
-		local crop = "^[sheet:4x4:" .. random(4) .. "," .. random(4)
+		local crop = "^[sheet:4x4:" .. random(0, 3) .. "," .. random(0, 3)
 		minetest.add_particlespawner({
 			pos = head_pos,
 			time = 0.5,


### PR DESCRIPTION
Texture modifier [\[sheet:\<w\>x\<h\>:\<x\>,\<y\>](https://api.minetest.net/textures/#sheetwxhxy) takes 0-indexed x,y parameters, but [math.random(4)](https://www.lua.org/manual/5.3/manual.html#pdf-math.random) will generate random numbers from 1 to 4, thus causing errors every time a "4" is created, for example:
```
2024-11-05 19:43:45: ERROR[Main]: generateImagePart(): invalid tile position (X,Y) for part_of_name="[sheet:4x4:4,4", cancelling.
2024-11-05 19:43:45: ERROR[Main]: generateImage(): Failed to generate "[sheet:4x4:4,4"
2024-11-05 19:43:48: ERROR[Main]: generateImagePart(): invalid tile position (X,Y) for part_of_name="[sheet:4x4:4,3", cancelling.
2024-11-05 19:43:48: ERROR[Main]: generateImage(): Failed to generate "[sheet:4x4:4,3"
```