### PR TITLE
cat: Fix trust increase after playing

### DIFF
--- a/api/api.lua
+++ b/api/api.lua
@@ -594,12 +594,12 @@ function animalia.random_sound(self)
 	end
 end
 
-function animalia.add_trust(self, player, amount)
+function animalia.add_trust(self, player, amount, max)
 	if self.trust_cooldown > 0 then return end
 	self.trust_cooldown = 60
 	local plyr_name = player:get_player_name()
 	local trust = self.trust[plyr_name] or 0
-	if trust > 4 then return end
+	if trust >= (max or 5) then return end
 	self.trust[plyr_name] = trust + (amount or 1)
 	self:memorize("trust", self.trust)
 end

--- a/api/mob_ai.lua
+++ b/api/mob_ai.lua
@@ -636,7 +636,7 @@ function animalia.action_play(self, target)
 
 		if stage == 2
 		and dist < mob.width + 1 then
-			animalia.add_trust(mob, target, 1)
+			animalia.add_trust(mob, target, 1, 10)
 
 			stage = 3
 		end


### PR DESCRIPTION
`add_trust` was hard capped at 5. As both feeding and playing with the cat used `add_trust` it was not possible to reach trust > 5. But for following orders, trust > 5 is required.

We allow to pass the max achievable trust as parameter to `add_trust`, and tune playing with the cat to allow reaching trust 10. This allows (by feeding and afterwards playing with it) to reach a trust > 5 for a cat. Then, the cat will follow orders.