### PR TITLE
Fix animate_player crashing the game when no recognized modpath exists

### DIFF
--- a/api/api.lua
+++ b/api/api.lua
@@ -79,7 +79,10 @@ local function activate_nametag(self)
 	})
 end
 
-animalia.animate_player = {}
+local function animate_player_stub(arg1, arg2, arg3)
+end
+
+animalia.animate_player = animate_player_stub
 
 if minetest.get_modpath("default")
 and minetest.get_modpath("player_api") then


### PR DESCRIPTION
Resolves "attempt to call field 'animate_player' (a table value)".

There might be heaps of other issues relating to being loaded on not minetest/mineclonia2, but this one just hard crashes the game.